### PR TITLE
Fix missing entries in alerts panel

### DIFF
--- a/src/scripts/gui/alerts.lua
+++ b/src/scripts/gui/alerts.lua
@@ -200,6 +200,8 @@ function alerts_tab.update(self)
         util.slot_table_update(row.contents_frame.contents_table, {
           { color = "green", entries = alerts_entry.planned_shipment or {}, translations = dictionaries.materials },
           { color = "red", entries = alerts_entry.actual_shipment or {}, translations = dictionaries.materials },
+          { color = "red", entries = alerts_entry.unscheduled_load or {}, translations = dictionaries.materials },
+          { color = "red", entries = alerts_entry.remaining_load or {}, translations = dictionaries.materials },
         })
       end
     end


### PR DESCRIPTION
Some alert types in the alerts tab (unscheduled_load and remaining_load) say they show the unexpected load in red, but only the actual shipment is shown in green.
Add other types of unexpected loads to the table.